### PR TITLE
This fixes an issue you have when performing a crop after a resize.

### DIFF
--- a/src/app/code/community/Varien/Image/Adapter/Imagemagic.php
+++ b/src/app/code/community/Varien/Image/Adapter/Imagemagic.php
@@ -171,6 +171,9 @@ class Varien_Image_Adapter_Imagemagic extends Varien_Image_Adapter_Abstract
             $imagick->clear();
             $imagick->destroy();
         }
+
+        $this->refreshImageDimensions();
+
         Varien_Profiler::stop(__METHOD__);
     }
 
@@ -180,6 +183,8 @@ class Varien_Image_Adapter_Imagemagic extends Varien_Image_Adapter_Abstract
     public function rotate($angle)
     {
         $this->getImageMagick()->rotateimage(new ImagickPixel(), $angle);
+
+        $this->refreshImageDimensions();
     }
 
     /**
@@ -193,13 +198,19 @@ class Varien_Image_Adapter_Imagemagic extends Varien_Image_Adapter_Abstract
         if ($left == 0 && $top == 0 && $right == 0 && $bottom == 0) {
             return;
         }
+
+        $newWidth = $this->_imageSrcWidth - $left - $right;
+        $newHeight = $this->_imageSrcHeight - $top - $bottom;
+
         /* because drlrdsen said so!  */
         $this->getImageMagick()->cropImage(
-            $right - $left,
-            $bottom - $top,
+            $newWidth,
+            $newHeight,
             $left,
             $top
         );
+
+        $this->refreshImageDimensions();
     }
 
     /**
@@ -318,6 +329,13 @@ class Varien_Image_Adapter_Imagemagic extends Varien_Image_Adapter_Abstract
             }
         }
         return true;
+    }
+
+    protected function refreshImageDimensions()
+    {
+        $this->_imageSrcWidth = $this->_imageHandler->getImageWidth();
+        $this->_imageSrcHeight = $this->_imageHandler->getImageHeight();
+        $this->_imageHandler->setImagePage($this->_imageSrcWidth, $this->_imageSrcHeight, 0, 0);
     }
 
     public function __destruct()


### PR DESCRIPTION
While trying to integrate the ImageMagick Adapter with the [AdaptiveResize extension](https://github.com/obukhow/AdaptiveResize) I noticed the cropping was completely wrong.
The extension first resizes and then crops, and there was an issue here.
You have to refresh the `_imageSrcWidth` and `_imageSrcHeight` members after a resize and use them in the crop, similar as the `Varien_Image_Adapter_Gd2` class is doing.

This pull request fixes this.

I took most of the code from the current [Magento2 ImageMagick integration](https://github.com/magento/magento2/blob/de2d869676e6e6a0b7819bd04f260719e7466725/lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php)