### PR TITLE
Fix Resize/keepFrame with matching dimension

### DIFF
--- a/src/app/code/community/Varien/Image/Adapter/Imagemagic.php
+++ b/src/app/code/community/Varien/Image/Adapter/Imagemagic.php
@@ -141,8 +141,10 @@ class Varien_Image_Adapter_Imagemagic extends Varien_Image_Adapter_Abstract
 
         // Fill desired canvas
         if ($this->keepFrame() === TRUE
-            && $frameWidth != $origWidth
-            && $frameHeight != $origHeight
+            && (
+                $frameWidth != $origWidth
+                || $frameHeight != $origHeight
+            )
         ) {
             $composite = new Imagick();
             $color = $this->_backgroundColor;


### PR DESCRIPTION
The logic in Resize() prevents keeping the frame if one of the original
dimensions matches the frame dimension. This patch keeps the frame if either of
the dimensions are different.
